### PR TITLE
Initialize player's rank with number of players instead of '0'

### DIFF
--- a/backend/manager/RoomManager.js
+++ b/backend/manager/RoomManager.js
@@ -171,7 +171,7 @@ class RoomManager {
         room.game.scores.push({
             player: player,
             value: 0,
-            rank: 0,
+            rank: room.players.length,
             lastAnswer: null,
         });
     };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Fixed issues  | Fixes # if any

Résout le bug en initialisant le classement du joueur avec le nombre de joueurs de la room plutôt que 0.