### PR TITLE
Reduce scores table display min-height

### DIFF
--- a/frontend/src/css/pages/question.css
+++ b/frontend/src/css/pages/question.css
@@ -436,7 +436,7 @@
 }
 
 @media screen and (max-width: 992px),
-       screen and (max-height: 980px) {
+       screen and (max-height: 840px) {
     .question-scores-table-title {
         display: none;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Yes/No
| New feature?  | Yes/No
| Fixed issues  | Fixes # if any

Finalement pas vraiment besoin d'autres changements, en approchant du breakpoint fatidique la table des scores est un peu compressée mais ça passe encore, et ça rend très bien sur un écran Full HD